### PR TITLE
Add images for postgres 9.4 and 9.5

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,6 +2,7 @@ postgresApp:
   image: busybox:latest
   depends_on:
     - postgres93
+    - postgres95
     - postgres96
     - postgres101
 
@@ -15,6 +16,12 @@ postgres93:
     image: codeship/postgres:93
     context: ./postgres
     dockerfile: 9.3.dockerfile
+
+postgres95:
+  build:
+    image: codeship/postgres:95
+    context: ./postgres
+    dockerfile: 9.5.dockerfile
 
 postgres96:
   build:

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,6 +2,7 @@ postgresApp:
   image: busybox:latest
   depends_on:
     - postgres93
+    - postgres94
     - postgres95
     - postgres96
     - postgres101
@@ -16,6 +17,12 @@ postgres93:
     image: codeship/postgres:93
     context: ./postgres
     dockerfile: 9.3.dockerfile
+
+postgres94:
+  build:
+    image: codeship/postgres:94
+    context: ./postgres
+    dockerfile: 9.4.dockerfile
 
 postgres95:
   build:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -14,6 +14,14 @@
       encrypted_dockercfg_path: dockercfg.encrypted
     - type: push
       tag: master
+      name: postgres95_push
+      service: postgres95
+      image_name: codeship/postgres
+      image_tag: "9.5"
+      registry: https://index.docker.io/v1/
+      encrypted_dockercfg_path: dockercfg.encrypted
+    - type: push
+      tag: master
       name: postgres96_push
       service: postgres96
       image_name: codeship/postgres

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -14,6 +14,14 @@
       encrypted_dockercfg_path: dockercfg.encrypted
     - type: push
       tag: master
+      name: postgres94_push
+      service: postgres94
+      image_name: codeship/postgres
+      image_tag: "9.4"
+      registry: https://index.docker.io/v1/
+      encrypted_dockercfg_path: dockercfg.encrypted
+    - type: push
+      tag: master
       name: postgres95_push
       service: postgres95
       image_name: codeship/postgres

--- a/postgres/9.4.dockerfile
+++ b/postgres/9.4.dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:9.4-alpine
+
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
+
+HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]

--- a/postgres/9.5.dockerfile
+++ b/postgres/9.5.dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:9.5-alpine
+
+COPY docker-healthcheck /usr/local/bin/
+RUN chmod u+x /usr/local/bin/docker-healthcheck
+
+HEALTHCHECK --timeout=120s --start-period=20s CMD ["docker-healthcheck"]


### PR DESCRIPTION
Include configuration to create and push images for postgres versions 9.4 and 9.5 using same healthcheck.